### PR TITLE
Add default headers if none is present

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -36,6 +36,8 @@ const (
 	headerRequestHeaders = "Access-Control-Request-Headers"
 )
 
+var defaultAllowHeaders = []string{"Origin", "Accept", "Content-Type", "Authorization"}
+
 // Represents Access Control options.
 type Options struct {
 	// If set, all origins are allowed.
@@ -152,6 +154,10 @@ func (o *Options) IsOriginAllowed(origin string) (allowed bool) {
 
 // Allows CORS for requests those match the provided options.
 func Allow(opts *Options) http.HandlerFunc {
+	// Allow default headers if nothing is specified.
+	if len(opts.AllowHeaders) == 0 {
+		opts.AllowHeaders = defaultAllowHeaders
+	}
 	return func(res http.ResponseWriter, req *http.Request) {
 		var (
 			origin           = req.Header.Get(headerOrigin)

--- a/cors_test.go
+++ b/cors_test.go
@@ -116,6 +116,22 @@ func Test_OtherHeaders(t *testing.T) {
 	}
 }
 
+func Test_DefaultAllowHeaders(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	m := martini.New()
+	m.Use(Allow(&Options{
+		AllowAllOrigins: true,
+	}))
+
+	r, _ := http.NewRequest("PUT", "foo", nil)
+	m.ServeHTTP(recorder, r)
+
+	headersVal := recorder.HeaderMap.Get(headerAllowHeaders)
+	if headersVal != "Origin,Accept,Content-Type,Authorization" {
+		t.Errorf("Allow-Headers is expected to be Origin,Accept,Content-Type,Authorization; found %v", headersVal)
+	}
+}
+
 func Test_Preflight(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	m := martini.New()


### PR DESCRIPTION
Origin and Accept, Content-Type, and Authorization could be the default headers if none is set.
