### PR TITLE
Add Allow-Origin header to the preflight response.

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -124,6 +124,13 @@ func (o *Options) PreflightHeader(origin, rMethod, rHeaders string) (headers map
 		}
 	}
 
+	// add allow origin
+	if o.AllowAllOrigins {
+		headers[headerAllowOrigin] = "*"
+	} else {
+		headers[headerAllowOrigin] = origin
+	}
+
 	// add allowed headers
 	if len(allowed) > 0 {
 		headers[headerAllowHeaders] = strings.Join(allowed, ",")

--- a/cors_test.go
+++ b/cors_test.go
@@ -148,6 +148,7 @@ func Test_Preflight(t *testing.T) {
 
 	methodsVal := recorder.HeaderMap.Get(headerAllowMethods)
 	headersVal := recorder.HeaderMap.Get(headerAllowHeaders)
+	originVal := recorder.HeaderMap.Get(headerAllowOrigin)
 
 	if methodsVal != "PUT,PATCH" {
 		t.Errorf("Allow-Methods is expected to be PUT,PATCH, found %v", methodsVal)
@@ -155,6 +156,10 @@ func Test_Preflight(t *testing.T) {
 
 	if headersVal != "X-whatever" {
 		t.Errorf("Allow-Headers is expected to be X-whatever, found %v", headersVal)
+	}
+
+	if originVal != "*" {
+		t.Errorf("Allow-Origin is expected to be *, found %v", originVal)
 	}
 }
 


### PR DESCRIPTION
Per https://developer.mozilla.org/en-US/docs/HTTP/Access_control_CORS#Preflighted_requests, the preflight response should contain the `Access-Control-Allow-Origin` header.

This pull request adds logic for this along with a corresponding test.
