### PR TITLE
Do case-insensitive matching and allow spaces in Access-Control-Request-Headers.

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -115,9 +115,10 @@ func (o *Options) PreflightHeader(origin, rMethod, rHeaders string) (headers map
 	// verify if requested headers are allowed
 	var allowed []string
 	for _, rHeader := range strings.Split(rHeaders, ",") {
+		rHeader = strings.TrimSpace(rHeader)
 	lookupLoop:
 		for _, allowedHeader := range o.AllowHeaders {
-			if rHeader == allowedHeader {
+			if strings.ToLower(rHeader) == strings.ToLower(allowedHeader) {
 				allowed = append(allowed, rHeader)
 				break lookupLoop
 			}

--- a/cors_test.go
+++ b/cors_test.go
@@ -17,6 +17,7 @@ package cors
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -138,12 +139,12 @@ func Test_Preflight(t *testing.T) {
 	m.Use(Allow(&Options{
 		AllowAllOrigins: true,
 		AllowMethods:    []string{"PUT", "PATCH"},
-		AllowHeaders:    []string{"Origin", "X-whatever"},
+		AllowHeaders:    []string{"Origin", "X-whatever", "X-CaseSensitive"},
 	}))
 
 	r, _ := http.NewRequest("OPTIONS", "foo", nil)
 	r.Header.Add(headerRequestMethod, "PUT")
-	r.Header.Add(headerRequestHeaders, "X-whatever")
+	r.Header.Add(headerRequestHeaders, "X-whatever, x-casesensitive")
 	m.ServeHTTP(recorder, r)
 
 	methodsVal := recorder.HeaderMap.Get(headerAllowMethods)
@@ -154,8 +155,12 @@ func Test_Preflight(t *testing.T) {
 		t.Errorf("Allow-Methods is expected to be PUT,PATCH, found %v", methodsVal)
 	}
 
-	if headersVal != "X-whatever" {
-		t.Errorf("Allow-Headers is expected to be X-whatever, found %v", headersVal)
+	if !strings.Contains(headersVal, "X-whatever") {
+		t.Errorf("Allow-Headers is expected to contain X-whatever, found %v", headersVal)
+	}
+
+	if !strings.Contains(headersVal, "x-casesensitive") {
+		t.Errorf("Allow-Headers is expected to contain x-casesensitive, found %v", headersVal)
 	}
 
 	if originVal != "*" {


### PR DESCRIPTION
This PR does case-insensitive matching and trims spaces when checking headers in the preflight response.

I ran into issues when using this middleware with Angular because it the Access-Control-Request-Headers in the OPTIONS request it sends are lowercase and have spaces after the comma separating them. This resolves that issue. It should also fix the first issue in #3.
