### PR TITLE
AllowOrigins allows for bypass

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ func main() {
   // - Origin header
   // - Credentials share
   m.Use(cors.Allow(&cors.Options{
-    AllowOrigins:     []string{"https://foo\\.*"},
+    AllowOrigins:     []string{"https://*.foo.com"},
     AllowMethods:     []string{"PUT", "PATCH"},
     AllowHeaders:     []string{"Origin"},
     ExposeHeaders:    []string{"Content-Length"},
@@ -32,7 +32,7 @@ You may alternatively prefer to allow CORS only for certain routes. Instead of u
 ~~~ go
 m := martini.Classic()
 allowCORSHandler := cors.Allow(&cors.Options{
-  AllowOrigins:     []string{"https://foo\\.*"},
+  AllowOrigins:     []string{"https://*.foo.com"},
   AllowMethods:     []string{"PUT", "PATCH"},
   AllowHeaders:     []string{"Origin"},
 })

--- a/cors.go
+++ b/cors.go
@@ -168,7 +168,7 @@ func Allow(opts *Options) http.HandlerFunc {
 	}
 	// Normalize regular expressions.
 	for i, pattern := range opts.AllowOrigins {
-		pattern := regexp.QuoteMeta(pattern)
+		pattern = regexp.QuoteMeta(pattern)
 		pattern = strings.Replace(pattern, "\\*", ".*", -1)
 		pattern = strings.Replace(pattern, "\\?", ".", -1)
 		opts.AllowOrigins[i] = "^" + pattern + "$"

--- a/cors.go
+++ b/cors.go
@@ -166,6 +166,15 @@ func Allow(opts *Options) http.HandlerFunc {
 	if len(opts.AllowHeaders) == 0 {
 		opts.AllowHeaders = defaultAllowHeaders
 	}
+	// Normalize regular expressions.
+	if len(opts.AllowOrigins) > 0 {
+		for i, pattern := range opts.AllowOrigins {
+			pattern := regexp.QuoteMeta(pattern)
+			pattern = strings.Replace(pattern, "\\*", ".*", -1)
+			pattern = strings.Replace(pattern, "\\?", ".", -1)
+			opts.AllowOrigins[i] = "^" + pattern + "$"
+		}
+	}
 	return func(res http.ResponseWriter, req *http.Request) {
 		var (
 			origin           = req.Header.Get(headerOrigin)

--- a/cors.go
+++ b/cors.go
@@ -167,13 +167,11 @@ func Allow(opts *Options) http.HandlerFunc {
 		opts.AllowHeaders = defaultAllowHeaders
 	}
 	// Normalize regular expressions.
-	if len(opts.AllowOrigins) > 0 {
-		for i, pattern := range opts.AllowOrigins {
-			pattern := regexp.QuoteMeta(pattern)
-			pattern = strings.Replace(pattern, "\\*", ".*", -1)
-			pattern = strings.Replace(pattern, "\\?", ".", -1)
-			opts.AllowOrigins[i] = "^" + pattern + "$"
-		}
+	for i, pattern := range opts.AllowOrigins {
+		pattern := regexp.QuoteMeta(pattern)
+		pattern = strings.Replace(pattern, "\\*", ".*", -1)
+		pattern = strings.Replace(pattern, "\\?", ".", -1)
+		opts.AllowOrigins[i] = "^" + pattern + "$"
 	}
 	return func(res http.ResponseWriter, req *http.Request) {
 		var (

--- a/cors_test.go
+++ b/cors_test.go
@@ -43,10 +43,10 @@ func Test_AllowRegexMatch(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	m := martini.New()
 	m.Use(Allow(&Options{
-		AllowOrigins: []string{"https://aaa.com", "https://foo\\.*"},
+		AllowOrigins: []string{"https://aaa.com", "https://*.foo.com"},
 	}))
 
-	origin := "https://foo.com"
+	origin := "https://bar.foo.com"
 	r, _ := http.NewRequest("PUT", "foo", nil)
 	r.Header.Add("Origin", origin)
 	m.ServeHTTP(recorder, r)
@@ -61,10 +61,10 @@ func Test_AllowRegexNoMatch(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	m := martini.New()
 	m.Use(Allow(&Options{
-		AllowOrigins: []string{"https://foo\\.*"},
+		AllowOrigins: []string{"https://*.foo.com"},
 	}))
 
-	origin := "https://bar.com"
+	origin := "https://ww.foo.com.evil.com"
 	r, _ := http.NewRequest("PUT", "foo", nil)
 	r.Header.Add("Origin", origin)
 	m.ServeHTTP(recorder, r)


### PR DESCRIPTION
Currently when matching the origin header of a request to AllowOrigins there is no verification of the start and end of the regex. Someone could abuse this. Consider the following example.

```
m.Use(Allow(&Options{
    AllowOrigins: []string{"https://www.foo.com"},
}))
```

The intention was to only allow from www.foo.com. However, the owner of bar.com could create a record for "www.foo.com.bar.com", allowing for bypass of the restriction. To resolve this I borrowed a solution from the Hapi.js framework. That is first escape the regex, replace needed characters to allow for wildcards, and then adding "^" and "$" to the regex.
