### PR TITLE
Simpler Allow method version, also return * for allow-origin when supplied as * in options

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -70,7 +70,7 @@ func (o *Options) Header(origin string) (headers map[string]string) {
 	}
 
 	// add allow origin
-	if o.AllowAllOrigins {
+	if o.AllowAllOrigins || (len(o.AllowOrigins) > 0 && o.AllowOrigins[0] == "*") {
 		headers[headerAllowOrigin] = "*"
 	} else {
 		headers[headerAllowOrigin] = origin
@@ -162,6 +162,14 @@ func (o *Options) IsOriginAllowed(origin string) (allowed bool) {
 		}
 	}
 	return
+}
+
+func AllowSimple(origin, methods, headers string) http.HandlerFunc {
+	return Allow(&Options{
+		AllowOrigins: []string{origin},
+		AllowMethods: strings.Split(methods, ","),
+		AllowHeaders: strings.Split(headers, ","),
+	})
 }
 
 // Allows CORS for requests those match the provided options.


### PR DESCRIPTION
Reasoning:

Creation of the options object to pass to the existing Allow() made client code needlessly verbose - a simple version that supplies the three most often used CORS headers makes martini setup code much more readable and clean.

Regarding the \* - it seemed unintuitive that whatever origin request header was sent was coming even though my client code was passing a \* into the handler.  Line 73 change remedies that condition.
