### PR TITLE
Defer preflight write headers until after headers are updated

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -192,7 +192,7 @@ func Allow(opts *Options) http.HandlerFunc {
 			(requestedMethod != "" || requestedHeaders != "") {
 			// TODO: if preflight, respond with exact headers if allowed
 			headers = opts.PreflightHeader(origin, requestedMethod, requestedHeaders)
-			res.WriteHeader(http.StatusOK)
+			defer res.WriteHeader(http.StatusOK)
 		} else {
 			headers = opts.Header(origin)
 		}

--- a/cors_test.go
+++ b/cors_test.go
@@ -22,36 +22,31 @@ import (
 	"time"
 
 	"github.com/go-martini/martini"
-	"bytes"
 )
 
 
 type HttpHeaderGuardRecorder struct {
-	httptest.ResponseRecorder
-	SavedHeaderMap http.Header
+	*httptest.ResponseRecorder
+	savedHeaderMap http.Header
 }
 
 
 func NewRecorder() *HttpHeaderGuardRecorder {
-	recorder := &HttpHeaderGuardRecorder{}
-	recorder.HeaderMap = make(http.Header)
-	recorder.Body = new(bytes.Buffer)
-	recorder.Code = 200
-	return recorder
+	return &HttpHeaderGuardRecorder{httptest.NewRecorder(), nil}
 }
 
 
 func (gr* HttpHeaderGuardRecorder) WriteHeader(code int) {
 	gr.ResponseRecorder.WriteHeader(code)
-	gr.SavedHeaderMap = gr.ResponseRecorder.Header()
+	gr.savedHeaderMap = gr.ResponseRecorder.Header()
 }
 
 
 func (gr* HttpHeaderGuardRecorder) Header() http.Header {
-	if gr.SavedHeaderMap != nil {
+	if gr.savedHeaderMap != nil {
 		// headers were written. clone so we don't get updates
 		clone := make(http.Header)
-		for k, v := range gr.SavedHeaderMap {
+		for k, v := range gr.savedHeaderMap {
 			clone[k] = v
 		}
 		return clone


### PR DESCRIPTION
In the preflight case, `res.WriteHeader()` is called before the headers are updated on the response, and thus the headers never make it out to the client.

This didn't show up in the tests, because `httptest.ResponseRecorder` lets you update headers after the response has been written. I added a new type to guard against this use case; the first commit demonstrates the failing preflight test.

The fix is to `defer` the call to write the headers. The second commit includes the fix.
