### PR TITLE
MVP-724 Fix the Martini CORS handler

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -192,7 +192,7 @@ func Allow(opts *Options) http.HandlerFunc {
 			(requestedMethod != "" || requestedHeaders != "") {
 			// TODO: if preflight, respond with exact headers if allowed
 			headers = opts.PreflightHeader(origin, requestedMethod, requestedHeaders)
-			res.WriteHeader(http.StatusOK)
+			defer res.WriteHeader(http.StatusOK)
 		} else {
 			headers = opts.Header(origin)
 		}


### PR DESCRIPTION
This fixes the Martini CORS handler for the channels code. Also submitted upstream, but forked to get the fix out so that we're unblocked.

/cc @cameront @oflorescu @peaches 
