### PR TITLE
add AllowCredentials header on OPTIONS request

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -129,6 +129,7 @@ func (o *Options) PreflightHeader(origin, rMethod, rHeaders string) (headers map
 		}
 	}
 
+	headers[headerAllowCredentials] = strconv.FormatBool(o.AllowCredentials)
 	// add allow origin
 	if o.AllowAllOrigins {
 		headers[headerAllowOrigin] = "*"


### PR DESCRIPTION
cross-domain requests with enabled credentials require credentials header on OPTIONS request.
