### PR TITLE
Avoid wildcard Access-Control-Allow-Origin when Access-Control-Allow-Credentials is true

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -136,6 +136,9 @@ func (o *Options) PreflightHeader(origin, rMethod, rHeaders string) (headers map
 		headers[headerAllowOrigin] = origin
 	}
 
+	// add allow credentials
+	headers[headerAllowCredentials] = strconv.FormatBool(o.AllowCredentials)
+
 	// add allowed headers
 	if len(allowed) > 0 {
 		headers[headerAllowHeaders] = strings.Join(allowed, ",")

--- a/cors.go
+++ b/cors.go
@@ -70,7 +70,7 @@ func (o *Options) Header(origin string) (headers map[string]string) {
 	}
 
 	// add allow origin
-	if o.AllowAllOrigins {
+	if o.AllowAllOrigins && !o.AllowCredentials {
 		headers[headerAllowOrigin] = "*"
 	} else {
 		headers[headerAllowOrigin] = origin
@@ -130,7 +130,7 @@ func (o *Options) PreflightHeader(origin, rMethod, rHeaders string) (headers map
 	}
 
 	// add allow origin
-	if o.AllowAllOrigins {
+	if o.AllowAllOrigins && !o.AllowCredentials {
 		headers[headerAllowOrigin] = "*"
 	} else {
 		headers[headerAllowOrigin] = origin

--- a/cors_test.go
+++ b/cors_test.go
@@ -24,25 +24,21 @@ import (
 	"github.com/go-martini/martini"
 )
 
-
 type HttpHeaderGuardRecorder struct {
 	*httptest.ResponseRecorder
 	savedHeaderMap http.Header
 }
 
-
 func NewRecorder() *HttpHeaderGuardRecorder {
 	return &HttpHeaderGuardRecorder{httptest.NewRecorder(), nil}
 }
 
-
-func (gr* HttpHeaderGuardRecorder) WriteHeader(code int) {
+func (gr *HttpHeaderGuardRecorder) WriteHeader(code int) {
 	gr.ResponseRecorder.WriteHeader(code)
 	gr.savedHeaderMap = gr.ResponseRecorder.Header()
 }
 
-
-func (gr* HttpHeaderGuardRecorder) Header() http.Header {
+func (gr *HttpHeaderGuardRecorder) Header() http.Header {
 	if gr.savedHeaderMap != nil {
 		// headers were written. clone so we don't get updates
 		clone := make(http.Header)
@@ -54,8 +50,6 @@ func (gr* HttpHeaderGuardRecorder) Header() http.Header {
 		return gr.ResponseRecorder.Header()
 	}
 }
-
-
 
 func Test_AllowAll(t *testing.T) {
 	recorder := httptest.NewRecorder()

--- a/cors_test.go
+++ b/cors_test.go
@@ -233,9 +233,14 @@ func Test_PreflightCredentials(t *testing.T) {
 	m.ServeHTTP(recorder, r)
 
 	headers := recorder.Header()
+	credentialsVal := recorder.HeaderMap.Get(headerAllowCredentials)
 	methodsVal := headers.Get(headerAllowMethods)
 	headersVal := headers.Get(headerAllowHeaders)
 	originVal := headers.Get(headerAllowOrigin)
+
+	if credentialsVal != "true" {
+		t.Errorf("Allow-Credentials is expected to be true, found %v", credentialsVal)
+	}
 
 	if methodsVal != "PUT,PATCH" {
 		t.Errorf("Allow-Methods is expected to be PUT,PATCH, found %v", methodsVal)


### PR DESCRIPTION
From [the spec](http://www.w3.org/TR/2008/WD-access-control-20080912/#access-control-allow-origin)

> For requests **without credentials**, a server can specify that a resource can be accessed
> by any origin using a wildcard: Access-Control-Allow-Origin: *

For wildcard `Access-Control-Allow-Origin` user agents will still issue requests, but the client cannot access the returned data (different user agents may behave differently here, some may refuse to make the request).  

From the [Mozilla docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS#Requests_with_credentials):

> **Important note**: when responding to a credentialed request,  server **must** 
> specify a domain, and cannot use wild carding.
