### PR TITLE
Use b.N in benchmarks

### DIFF
--- a/cors_test.go
+++ b/cors_test.go
@@ -215,7 +215,7 @@ func Benchmark_WithoutCORS(b *testing.B) {
 	m := martini.New()
 
 	b.ResetTimer()
-	for i := 0; i < 100; i++ {
+	for i := 0; i < b.N; i++ {
 		r, _ := http.NewRequest("PUT", "foo", nil)
 		m.ServeHTTP(recorder, r)
 	}
@@ -233,7 +233,7 @@ func Benchmark_WithCORS(b *testing.B) {
 	}))
 
 	b.ResetTimer()
-	for i := 0; i < 100; i++ {
+	for i := 0; i < b.N; i++ {
 		r, _ := http.NewRequest("PUT", "foo", nil)
 		m.ServeHTTP(recorder, r)
 	}


### PR DESCRIPTION
Currently, the output of `go test -bench=.` is not very useful

```
[martini] Started OPTIONS foo for 
[martini] Completed 200 OK in 154.09us
PASS
Benchmark_WithoutCORS   2000000000           0.00 ns/op
Benchmark_WithCORS  2000000000           0.00 ns/op
ok      github.com/hariharan-uno/cors   0.014s
```

After this change, the output is informative

```
[martini] Started OPTIONS foo for 
[martini] Completed 200 OK in 150.767us
PASS
Benchmark_WithoutCORS    1000000          2221 ns/op
Benchmark_WithCORS    500000          6900 ns/op
ok      github.com/hariharan-uno/cors   5.778s
```
